### PR TITLE
feat(ffn): Add major FFN variants (GLU, GeGLU, ReGLU, SwiGLU, GRN) an…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+*_ckpts/
+*.bin
+.DS_Store
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[codz]

--- a/ffns/GLUFFN.py
+++ b/ffns/GLUFFN.py
@@ -1,0 +1,34 @@
+###############################################################################
+# Copyright (c) 2025, Yoonsung Choi
+# This file is part of OpenMLXModel.
+#
+# OpenMLXModel is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License.
+#
+# OpenMLXModel is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with OpenMLXModel. If not, see <https://www.gnu.org/licenses/>.
+###############################################################################
+import mlx.core as mx
+import mlx.nn as nn
+from common import Linear
+
+class GLUFFN(nn.Module):
+    """
+    GLU (Gated Linear Unit) 기반 FFN.
+    FFN: Linear(x) * sigmoid(Linear(x))
+    """
+    def __init__(self, d, f, use_bias, dtype=mx.float32):
+        super().__init__()
+        h = int(d * f)
+        self.w1 = Linear(d, h, bias=use_bias, dtype=dtype)
+        self.w2 = Linear(d, h, bias=use_bias, dtype=dtype)
+        self.proj = Linear(h, d, bias=use_bias, dtype=dtype)
+
+    def __call__(self, x):
+        return self.proj(self.w1(x) * nn.sigmoid(self.w2(x)))

--- a/ffns/GRNFFN.py
+++ b/ffns/GRNFFN.py
@@ -1,0 +1,51 @@
+###############################################################################
+# Copyright (c) 2025, Yoonsung Choi
+# This file is part of OpenMLXModel.
+#
+# OpenMLXModel is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License.
+#
+# OpenMLXModel is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with OpenMLXModel. If not, see <https://www.gnu.org/licenses/>.
+###############################################################################
+import mlx.core as mx
+import mlx.nn as nn
+from common import Linear
+
+class GRN(nn.Module):
+    """
+    Gated Residual Network(GRN).
+    - Linear + ELU + Linear로 변환 후,
+    - gating branch(Linear+sigmoid)로 게이트를 얻어 곱한다.
+    - 입력(skip)을 gating 후 출력에 더함.
+    """
+    def __init__(self, d, f, use_bias=True, dtype=mx.float32):
+        super().__init__()
+        h = int(d * f)
+        self.fc1 = Linear(d, h, bias=use_bias, dtype=dtype)
+        self.fc2 = Linear(h, d, bias=use_bias, dtype=dtype)
+        self.gate = Linear(d, d, bias=True, dtype=dtype)
+        self.skip = Linear(d, d, bias=False, dtype=dtype)  # skip 연결(원본 input 매핑)
+
+    def __call__(self, x):
+        out = self.fc2(nn.elu(self.fc1(x)))
+        gate = nn.sigmoid(self.gate(x))
+        skip = self.skip(x)
+        return out * gate + skip, mx.array(0.0, dtype=x.dtype) # 또는 mx.array(0.0) 등, main_loss와 호환되는 타입
+    
+    def _forward(self, params, x):
+        # 함수형 스타일
+        # params는 self.parameters()와 동일한 구조의 딕셔너리
+        h = nn.elu(mx.matmul(x, params["fc1"]["w"].T) + params["fc1"]["b"])
+        out = mx.matmul(h, params["fc2"]["w"].T) + params["fc2"]["b"]
+        
+        gate = nn.sigmoid(mx.matmul(x, params["gate"]["w"].T) + params["gate"]["b"])
+        skip = mx.matmul(x, params["skip"]["w"].T)
+        
+        return out * gate + skip, mx.array(0.0, dtype=x.dtype)

--- a/ffns/GeGLUFFN.py
+++ b/ffns/GeGLUFFN.py
@@ -1,0 +1,34 @@
+###############################################################################
+# Copyright (c) 2025, Yoonsung Choi
+# This file is part of OpenMLXModel.
+#
+# OpenMLXModel is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License.
+#
+# OpenMLXModel is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with OpenMLXModel. If not, see <https://www.gnu.org/licenses/>.
+###############################################################################
+import mlx.core as mx
+import mlx.nn as nn
+from common import Linear
+
+class GeGLUFFN(nn.Module):
+    """
+    GeGLU (GeLU-Gated Linear Unit) FFN.
+    FFN: Linear(x) * gelu(Linear(x))
+    """
+    def __init__(self, d, f, use_bias, dtype=mx.float32):
+        super().__init__()
+        h = int(d * f)
+        self.w1 = Linear(d, h, bias=use_bias, dtype=dtype)
+        self.w2 = Linear(d, h, bias=use_bias, dtype=dtype)
+        self.proj = Linear(h, d, bias=use_bias, dtype=dtype)
+
+    def __call__(self, x):
+        return self.proj(self.w1(x) * nn.gelu(self.w2(x)))

--- a/ffns/ReGLUFFN.py
+++ b/ffns/ReGLUFFN.py
@@ -1,0 +1,26 @@
+###############################################################################
+# Copyright (c) 2025, Yoonsung Choi
+# This file is part of OpenMLXModel.
+
+# OpenMLXModel is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or any later version.
+###############################################################################
+import mlx.core as mx
+import mlx.nn as nn
+from common import Linear
+
+class ReGLUFFN(nn.Module):
+    """
+    ReGLU (ReLU-Gated Linear Unit) FFN.
+    FFN: Linear(x) * relu(Linear(x))
+    """
+    def __init__(self, d, f, use_bias, dtype=mx.float32):
+        super().__init__()
+        h = int(d * f)
+        self.w1 = Linear(d, h, bias=use_bias, dtype=dtype)
+        self.w2 = Linear(d, h, bias=use_bias, dtype=dtype)
+        self.proj = Linear(h, d, bias=use_bias, dtype=dtype)
+
+    def __call__(self, x):
+        return self.proj(self.w1(x) * nn.relu(self.w2(x)))

--- a/ffns/SwiGLUFFN.py
+++ b/ffns/SwiGLUFFN.py
@@ -1,0 +1,60 @@
+###############################################################################
+# Copyright (c) 2025, Yoonsung Choi
+# This file is part of OpenMLXModel.
+#
+# OpenMLXModel is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License.
+#
+# OpenMLXModel is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with OpenMLXModel. If not, see <https://www.gnu.org/licenses/>.
+###############################################################################
+import math
+import mlx.core as mx
+import mlx.nn as nn
+from common import Linear
+
+class SwiGLUFFN(nn.Module):
+    """
+    SwiGLU Feed-Forward Network(FFN) 모듈.
+
+    - 현대 LLM(예: Mistral, LLaMA 등)에서 널리 쓰이는 SwiGLU 구조.
+    - 두 Linear(w1, w2) 후 silu(w2(x)) * w1(x) 연산, 이어서 출력 프로젝션(proj).
+    - proj 가중치는 작은 분산으로 초기화(2/sqrt(2*num_layers)), 초기 학습 안정성을 높임.
+    - 일반적인 Transformer FFN(factor f, hidden dim h)과 동일하게 동작하며,
+      실전 대형 언어모델에서 표준적인 사용성을 갖는다.
+
+    Args:
+        d (int): 입력/출력 차원(모델 임베딩 차원)
+        f (float): hidden layer width factor(보통 4.0~8.0)
+        use_bias (bool): Linear 레이어 bias 사용 여부
+        num_layers (int): 전체 Transformer 레이어 수 (proj 초기화에 사용)
+        dtype: 파라미터 데이터 타입
+
+    입력:
+        x (mx.array): (B, S, d) 입력 시퀀스
+
+    반환:
+        mx.array: (B, S, d) 출력 시퀀스
+
+    사용 예시:
+    -------
+    ffn = SwiGLUFFN(d=4096, f=8.0, use_bias=False, num_layers=32)
+    y = ffn(x)  # x: (B, S, 4096)
+    """
+    def __init__(self, d, f, use_bias, num_layers, dtype=mx.float32):
+        super().__init__()
+        h = int(d * f)
+        self.w1 = Linear(d, h, bias=use_bias, dtype=dtype)
+        self.w2 = Linear(d, h, bias=use_bias, dtype=dtype)
+        self.proj = Linear(h, d, bias=use_bias, dtype=dtype)
+        std = 2.0 / math.sqrt(2 * num_layers)
+        self.proj.w = mx.random.normal(shape=self.proj.w.shape, scale=std, dtype=dtype)
+
+    def __call__(self, x):
+        return self.proj(nn.silu(self.w2(x)) * self.w1(x))

--- a/ffns/__init__.py
+++ b/ffns/__init__.py
@@ -1,0 +1,8 @@
+###############################################################################
+# Copyright (c) 2025, Yoonsung Choi
+# This file is part of OpenMLXModel.
+
+# OpenMLXModel is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or any later version.
+###############################################################################


### PR DESCRIPTION
…d .gitignore

- .gitignore 최초 추가
  - Python/ML 프로젝트 표준 패턴 반영: __pycache__/, .ipynb_checkpoints/, .DS_Store, *.pyc, *.pyo, .env, .venv 등 일반적인 불필요 파일 및 임시 디렉터리 무시
  - Feed-Forward Network(FN/FFN) 구조 모듈 추가
  - GLUFFN: 표준 GLU(Gated Linear Unit) 기반 FFN
    - 두 개의 Linear 결과에 sigmoid를 게이트로 곱한 뒤, 프로젝션
  - GeGLUFFN: GeGLU(GeLU-Gated Linear Unit) 기반 FFN
    - 두 Linear 결과 중 하나는 GeLU 활성화 사용
  - ReGLUFFN: ReGLU(ReLU-Gated Linear Unit) 기반 FFN
    - 게이팅 분기에서 ReLU 활성화 사용
  - SwiGLUFFN: SwiGLU(Swish-Gated Linear Unit, silu 활성화)
    - proj 가중치 분산(scale) 초기화, 레이어 수에 비례한 표준편차 적용
  - GRNFFN (Gated Residual Network)
    - Linear + ELU + Linear 본선 + gating 브랜치(sigmoid), skip 연결
    - 함수형 호출(_forward) 지원