### PR TITLE
feat(embedding): Add Embedding module with explicit initialization and dtype control

### DIFF
--- a/embedding.py
+++ b/embedding.py
@@ -1,0 +1,38 @@
+###############################################################################
+# Copyright (c) 2025, Yoonsung Choi
+# This file is part of OpenMLXModel.
+#
+# OpenMLXModel is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License.
+#
+# OpenMLXModel is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with OpenMLXModel. If not, see <https://www.gnu.org/licenses/>.
+###############################################################################
+import math
+import mlx.core as mx
+import mlx.nn as nn
+
+class Embedding(nn.Module):
+    def __init__(self, vocab, d, dtype = mx.float32):
+        super().__init__()
+        # nn.Embedding 자체는 dtype을 직접 받지 않으므로, 내부의 weight를 직접 초기화해주는 것이 올바름
+        self.tok=nn.Embedding(vocab, d)
+
+        # 1. 작은 표준편차로 명시적 초기화
+        # 2. DTYPE을 명시적으로 지정하여 타입 일관성 확보
+        std = 1.0 / math.sqrt(d)
+        self.tok.weight = mx.random.normal(
+            shape=self.tok.weight.shape,
+            scale=std,
+            dtype=dtype
+        )
+
+    def __call__(self,ids):
+        x = self.tok(ids)
+        return x, None


### PR DESCRIPTION
- embedding.py 신규 추가, OpenMLXModel 전용 임베딩 레이어 구현
- MLX 백엔드에서 nn.Embedding 래핑, 직접 가중치(weight) 초기화로 데이터 타입 일관성 확보
  - 임베딩 행렬을 작은 표준편차(1/sqrt(d))의 정규분포로 명시적 초기화
  - dtype 명시적 지정: float32 등 모델 전체 타입 일치 보장
- 호출 시, 입력 토큰 id를 임베딩 벡터로 매핑하여 (임베딩, None) 반환
- 실제 사용상, embedding dropout 등 추가 구현의 기반이 됨