### PR TITLE
feat(moe): Add MoE infra, functional_linear, kernel-optimized LatentAttention, and GatelessMoELLM demo

### DIFF
--- a/examples/GatelessMoELLM/generate.py
+++ b/examples/GatelessMoELLM/generate.py
@@ -1,0 +1,330 @@
+###############################################################################
+# Copyright (c) 2025, Yoonsung Choi
+# This file is part of OpenMLXModel.
+#
+# OpenMLXModel is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License.
+#
+# OpenMLXModel is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with OpenMLXModel. If not, see <https://www.gnu.org/licenses/>.
+###############################################################################
+import mlx.core as mx
+import mlx.nn as nn
+from mlx.utils import tree_map
+import argparse, pathlib, json, sys
+
+from attentions.LatentAttention import LatentAttentionInfer
+from embedding import Embedding
+from ffns.GRNFFN import GRN
+from common import (
+    Linear,
+    RMSNorm,
+    LayerScale,
+    rope_cache,
+    causal_mask,
+    one_hot
+)
+
+from examples.GatelessMoELLM.train import (
+    LLM_CONFIG,
+    load_encoding
+)
+
+class MOELayer(nn.Module):
+    """
+    라우팅 행렬을 직접 입력받는 MoE 레이어.
+    """
+    def __init__(self, d: int, f: float, use_bias: bool, num_experts: int, dtype: mx.Dtype):
+        super().__init__()
+        self.num_experts = num_experts
+        self.experts = [GRN(d, f, use_bias, dtype=dtype) for _ in range(num_experts)]
+
+    def __call__(self, x: mx.array, routing_matrix: mx.array):
+        """
+        x: 입력 텐서 (B, S, D)
+        routing_matrix: (B, S, E) shape의 라우팅 행렬.
+        """
+        B, S, D = x.shape
+        x_reshaped = x.reshape(-1, D)
+        routing_matrix_flat = routing_matrix.reshape(-1, self.num_experts)
+
+        # vmap을 사용하여 모든 전문가를 병렬로 실행합니다.
+        # 이 단계는 학습 시와 동일한 로직을 사용합니다.
+        stacked_expert_params = tree_map(lambda *p: mx.stack(p, axis=0), *[exp.parameters() for exp in self.experts])
+        
+        vmapped_expert_fn = mx.vmap(
+            GRN.functional_forward,
+            in_axes=(None, 0),
+            out_axes=0
+        )
+        all_expert_outputs = vmapped_expert_fn(x_reshaped, stacked_expert_params)
+
+        # einsum을 사용하여 라우팅 행렬에 따라 전문가 출력을 가중 합산합니다.
+        final_flat_output = mx.einsum('end,ne->nd', all_expert_outputs, routing_matrix_flat)
+
+        return final_flat_output.reshape(B, S, D)
+
+class InferBlock(nn.Module):
+    """추론용 Block. 라우팅 행렬을 받아서 MOELayer에 전달합니다."""
+    def __init__(self, d, nh, nkv, r, f, use_bias, num_experts=1, dtype=mx.bfloat16):
+        super().__init__()
+        self.n1 = RMSNorm(d, dtype=dtype)
+        self.R1 = LayerScale(d, dtype=dtype)
+        self.n2 = RMSNorm(d, dtype=dtype)
+        self.R2 = LayerScale(d, dtype=dtype)
+        self.attn = LatentAttentionInfer(d, nh, nkv, r, use_bias, dtype=dtype)
+        self.ffn = MOELayer(d, f, use_bias, num_experts, dtype=dtype)
+
+    def __call__(self, x: mx.array, routing_matrix: mx.array, c, m: mx.array):
+        x = x + self.R1(self.attn(self.n1(x), c, m))
+        normed_x = self.n2(x)
+        ffn_output = self.ffn(normed_x, routing_matrix)
+        x = x + self.R2(ffn_output)
+        return x
+
+class InferLLMMini(nn.Module):
+    """추론용 전체 모델. 라우팅 행렬을 받아서 각 Block에 전달합니다."""
+    def __init__(self, vocab, seq, d, layers, heads, kv_heads, f=4, use_bias=True, dtype=mx.bfloat16, num_experts=1):
+        super().__init__()
+        self.dtype = dtype
+        self.embed = Embedding(vocab, d, dtype=dtype)
+        rope = rope_cache(seq, d // heads)
+        self.blocks = [InferBlock(d, heads, kv_heads, rope, f, use_bias, num_experts, dtype=dtype) for _ in range(layers)]
+        self.norm = RMSNorm(d, dtype=dtype)
+        self.lm_head = Linear(d, vocab, bias=False, dtype=dtype)
+        self.lm_head.weight = self.embed.tok.weight
+        self.cache = [{} for _ in range(layers)]
+
+    def __call__(self, ids: mx.array, routing_matrix: mx.array, m: mx.array = None):
+        x, _ = self.embed(ids)
+        for i, b in enumerate(self.blocks):
+            x = b(x, routing_matrix=routing_matrix, c=self.cache[i], m=m)
+        x_norm = self.norm(x)
+        logits = self.lm_head(x_norm)
+        return logits
+
+def sample(logits: mx.array, temp: float = 1.0, top_p: float = 0.9):
+    """
+    Top-p (nucleus) 샘플링과 temperature를 적용하여 다음 토큰을 선택합니다.
+    """
+    # temperature 적용
+    if temp > 0:
+        logits /= temp
+    
+    # 소프트맥스를 통해 확률 분포 생성
+    probs = mx.softmax(logits, axis=-1)
+    
+    # top-p (nucleus) 샘플링
+    sorted_probs = mx.sort(probs)[::-1]
+    cumulative_probs = mx.cumsum(sorted_probs, axis=-1)
+    
+    # p를 초과하는 확률을 가진 토큰들을 제외할 인덱스를 찾음
+    cutoff_index = mx.sum(cumulative_probs < top_p)
+    cutoff_value = sorted_probs[cutoff_index]
+    
+    # cutoff 값보다 작은 확률을 가진 토큰들은 확률을 0으로 설정
+    probs = mx.where(probs < cutoff_value, 0.0, probs)
+    
+    # 확률 재정규화
+    probs /= mx.sum(probs)
+    
+    # 재정규화된 확률 분포에서 샘플링
+    return mx.random.categorical(mx.log(probs))
+
+def generate(
+    model: InferLLMMini, # 임포트한 모델 클래스 이름과 일치시켜야 함
+    tokenizer,
+    prompt: str,
+    expert_ids: list[int],
+    expert_weights: list[float],
+    max_tokens: int = 100,
+    temp: float = 0.8,
+    top_p: float = 0.9,
+):
+    """
+    프롬프트를 기반으로 텍스트를 생성합니다. (KV 캐시 적용 버전)
+    """
+    expert_info = " | ".join([f"Expert {eid}: {w:.2f}" for eid, w in zip(expert_ids, expert_weights)])
+    print(f"\n[Using Expert Mix: {expert_info}]\n", flush=True)
+    
+    print(f"Prompt: {prompt}", end="", flush=True)
+
+    # 1. 라우팅 행렬 생성
+    num_experts = model.blocks[0].ffn.num_experts
+    # (E,) shape의 기본 라우팅 벡터 생성
+    base_routing_vector = mx.zeros((num_experts,), dtype=model.dtype)
+    # 지정된 위치에 가중치 설정. MLX는 인덱싱을 통한 업데이트를 지원.
+    # 이 연산을 위해 mx.array로 변환 필요
+    mx_expert_ids = mx.array(expert_ids)
+    mx_expert_weights = mx.array(expert_weights, dtype=model.dtype)
+    
+    # MLX에서 scatter 업데이트는 직접 지원하지 않으므로, one-hot을 활용하여 만듭니다.
+    routing_vector = mx.sum(one_hot(mx_expert_ids, num_experts) * mx_expert_weights[:, None], axis=0)
+    
+    # 프롬프트를 토큰화하고 모델에 입력 (Prefill 단계)
+    prompt_tokens = mx.array([tokenizer.encode(prompt)])
+    B, S = prompt_tokens.shape
+
+    # 프롬프트를 위한 라우팅 행렬 브로드캐스팅
+    # (E,) -> (1, 1, E) -> (B, S, E)
+    routing_matrix = mx.broadcast_to(routing_vector.reshape(1, 1, -1), (B, S, num_experts))
+
+    # 단일 토큰을 위한 라우팅 행렬 (B=1, S=1, E)
+    single_token_routing_matrix = routing_vector.reshape(1, 1, -1)
+
+    # 프롬프트 길이만큼 마스크 생성
+    mask = causal_mask(S, dtype=mx.bfloat16)
+    
+    # 맨 처음에는 전체 프롬프트에 대한 logits과 KV 캐시를 생성합니다.
+    # 이 단계에서 KV 캐시는 모든 블록에 대해 채워집니다.
+    y = model(prompt_tokens, single_token_routing_matrix, m=mask)
+    
+    # 마지막 토큰의 로짓만 사용하여 첫 번째 새로운 토큰을 샘플링합니다.
+    last_token_logits = y[:, -1, :]
+    next_token = sample(last_token_logits, temp, top_p)
+    
+    # 생성된 토큰을 즉시 디코딩하여 출력
+    token_text = tokenizer.decode(next_token.tolist())
+    print(token_text, end="", flush=True)
+
+    # 2. 자기회귀 생성 루프 (Decode 단계)
+    #    - 이제부터는 매번 토큰을 '하나씩만' 모델에 입력합니다.
+    #    - KV 캐시는 각 블록의 __call__ 메소드 내에서 자동으로 관리됩니다.
+    for i in range(max_tokens - 1):
+        # 모델에 이전에 생성된 '단일' 토큰을 입력합니다.
+        y = model(next_token.reshape(1, 1), single_token_routing_matrix, m=mask)
+        
+        # 모델 출력은 항상 (B, S, V) 형태이므로, S=1인 로짓을 가져옵니다.
+        logits = y[:, -1, :]
+        
+        # 다음 토큰 샘플링
+        next_token = sample(logits, temp, top_p)
+
+        # 생성된 토큰을 즉시 디코딩하여 출력
+        token_text = tokenizer.decode(next_token.tolist())
+        print(token_text, end="", flush=True)
+        
+        # EOT 토큰이 생성되면 루프 종료
+        if next_token.item() == tokenizer.eot_token:
+            break
+
+    print("\n\n[Done]")
+
+# PYTHONPATH=. uv run examples/GatelessMoELLM/generate.py --resume moe_ckpts/ckpt_001300.json --prompt "행복의 비밀은 " --expert-ids 2
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Generate text from a trained model.")
+    parser.add_argument(
+        "--resume",
+        type=str,
+        required=True,
+        help="Path to the checkpoint JSON file (e.g., ckpts/ckpt_000100.json).",
+    )
+    parser.add_argument(
+        "--prompt",
+        type=str,
+        default="In a shocking finding, scientists discovered a herd of unicorns living in a remote, previously unexplored valley, in the Andes Mountains.",
+        help="The prompt to start generation from.",
+    )
+    parser.add_argument(
+        "--max_tokens", type=int, default=200, help="Maximum number of tokens to generate."
+    )
+    parser.add_argument(
+        "--temp", type=float, default=0.8, help="Sampling temperature."
+    )
+    parser.add_argument(
+        "--top_p", type=float, default=0.9, help="Top-p (nucleus) sampling."
+    )
+    parser.add_argument(
+        "--expert-ids",
+        type=int,
+        nargs='+', # 여러 값을 받을 수 있도록 설정
+        required=True,
+        help="Space-separated list of expert IDs to use (e.g., 0 2 7)."
+    )
+    parser.add_argument(
+        "--expert-weights",
+        type=float,
+        nargs='+',
+        help="Space-separated list of weights for the experts. Must match the number of expert-ids. Defaults to uniform weights if not provided."
+    )
+    args = parser.parse_args()
+
+    # --- 가중치 유효성 검사 ---
+    expert_ids = args.expert_ids
+    expert_weights = args.expert_weights
+
+    if expert_weights is None:
+        # 가중치가 제공되지 않으면 균등하게 분배
+        num = len(expert_ids)
+        expert_weights = [1.0 / num] * num
+        print(f"No weights provided, using uniform weights: {expert_weights}")
+    elif len(expert_ids) != len(expert_weights):
+        sys.exit("Error: The number of --expert-ids and --expert-weights must be the same.")
+    
+    # 가중치 합이 1에 가깝도록 정규화 (선택 사항이지만 권장)
+    total_weight = sum(expert_weights)
+    if abs(total_weight - 1.0) > 1e-6:
+        print(f"Warning: Expert weights sum to {total_weight}. Normalizing to 1.0.")
+        expert_weights = [w / total_weight for w in expert_weights]
+
+    # 1. 체크포인트 메타데이터 로드
+    ckpt_path = pathlib.Path(args.resume)
+    if not ckpt_path.exists():
+        raise FileNotFoundError(f"Checkpoint metadata not found: {ckpt_path}")
+
+    with open(ckpt_path, "r") as f:
+        meta = json.load(f)
+
+    # 2. 모델 설정 및 토크나이저 로드
+    preset = meta["preset"]
+    enc_name = meta["enc"]
+    kv_heads = meta["kv_heads"]
+    
+    cfg = LLM_CONFIG[preset]
+    tokenizer, vocab_size = load_encoding(enc_name)
+
+    # 3. 모델 아키텍처 생성
+    model = InferLLMMini(
+        vocab_size,
+        cfg["block_size"],
+        cfg["embd_dim"],
+        cfg["num_layers"],
+        cfg["num_heads"],
+        kv_heads,
+        use_bias=cfg["use_bias"],
+        dtype = mx.bfloat16,
+        num_experts = cfg["num_experts"],
+    )
+
+    # 4. 가중치 로드
+    step = meta.get("step", 0)
+    weights_path = ckpt_path.with_name(f"ckpt_{step:06d}_weights.safetensors")
+    if not weights_path.exists():
+        raise FileNotFoundError(f"Weight file not found: {weights_path}")
+
+    print(f"Loading model weights from {weights_path}...")
+    model.load_weights(str(weights_path))
+    model.eval() # 모델을 평가 모드로 설정 (dropout 등 비활성화)
+    mx.eval(model.parameters()) # 모델 파라미터를 실제로 로드
+
+    print("\nModel loaded successfully. Starting generation...")
+    print("-" * 50)
+
+    # 5. 텍스트 생성 실행
+    generate(
+        model,
+        tokenizer,
+        args.prompt,
+        expert_ids=expert_ids,
+        expert_weights=expert_weights,
+        max_tokens=args.max_tokens,
+        temp=args.temp,
+        top_p=args.top_p,
+    )

--- a/examples/GatelessMoELLM/train.py
+++ b/examples/GatelessMoELLM/train.py
@@ -1,0 +1,439 @@
+###############################################################################
+# Copyright (c) 2025, Yoonsung Choi
+# This file is part of OpenMLXModel.
+#
+# OpenMLXModel is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License.
+#
+# OpenMLXModel is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with OpenMLXModel. If not, see <https://www.gnu.org/licenses/>.
+###############################################################################
+import mlx.core as mx
+import mlx.nn as nn
+import mlx.optimizers as optim
+import tiktoken
+import numpy as np # only for data Loader
+import math, argparse, sys, pathlib, json
+
+from typing import Dict, Tuple
+from mlx.utils import tree_unflatten, tree_flatten, tree_map
+from attentions.LatentAttention import LatentAttentionTrain
+from ffns.GRNFFN import GRN
+from embedding import Embedding
+from common import (
+    Linear,
+    RMSNorm,
+    LayerScale,
+    one_hot,
+    rope_cache,
+    causal_mask,
+    count_params
+)
+
+class MOELayer(nn.Module):
+    """
+    데이터 라벨에 따라 전문가를 명시적으로 선택하는 MoE 레이어.
+    """
+    def __init__(self, d: int, f: float, use_bias: bool, num_experts: int, dtype: mx.Dtype):
+        super().__init__()
+        self.num_experts = num_experts
+        # 각 라벨에 해당하는 전문가를 생성합니다.
+        self.experts = [GRN(d, f, use_bias, dtype=dtype) for _ in range(num_experts)]
+
+    def __call__(self, x: mx.array, labels: mx.array):
+        """
+        x: 입력 텐서 (B, S, D)
+        labels: 각 토큰에 대한 전문가를 지정하는 라벨 텐서 (B, S)
+        """
+        B, S, D = x.shape
+        x_reshaped = x.reshape(-1, D)
+        labels_flat = labels.reshape(-1)
+
+        # 1. 모든 토큰을 모든 전문가에게 전달 (vmap)
+        stacked_expert_params = tree_map(lambda *p: mx.stack(p, axis=0), *[exp.parameters() for exp in self.experts])
+        
+        # GRN의 __call__을 직접 참조하되, 파라미터를 명시적으로 전달하는 람다 함수 사용
+        vmapped_expert_fn = mx.vmap(
+            GRN.functional_forward,
+            in_axes=(None, 0),
+            out_axes=0
+        )
+        
+        all_expert_outputs = vmapped_expert_fn(x_reshaped, stacked_expert_params)
+
+        # 2. 라벨로부터 라우팅 행렬 생성 (핵심)
+        # 라벨을 원-핫 인코딩하여 라우팅 행렬을 직접 만듭니다.
+        # 이 행렬의 각 행은 해당 토큰이 가야 할 전문가 위치에만 1을 가집니다.
+        routing_matrix = one_hot(labels_flat, self.num_experts).astype(x.dtype)
+        
+        # 3. 가중 합산 (einsum)
+        # routing_matrix에 의해 정확히 라벨에 해당하는 전문가의 출력만 선택됩니다.
+        final_flat_output = mx.einsum('end,ne->nd', all_expert_outputs, routing_matrix)
+
+        # 이 방식에서는 MoE의 부하 분산 손실(aux_loss)이 의미가 없습니다.
+        # 라우팅이 학습되지 않기 때문입니다.
+        return final_flat_output.reshape(B, S, D)
+
+class Block(nn.Module):
+    def __init__(self, d, nh, nkv, r, f, use_bias, num_experts=1, dtype = mx.bfloat16):
+        super().__init__()
+        self.n1 = RMSNorm(d, dtype=dtype)
+        self.R1 = LayerScale(d, dtype=dtype)
+        self.n2 = RMSNorm(d, dtype=dtype)
+        self.R2 = LayerScale(d, dtype=dtype)
+        self.attn = LatentAttentionTrain(d, nh, nkv, r, use_bias, dtype = dtype)
+        self.ffn = MOELayer(d, f, use_bias, num_experts, dtype = dtype)
+
+    def __call__(self, x, labels: mx.array, m):
+        x = x + self.R1(self.attn(self.n1(x), m))
+        normed_x = self.n2(x)
+        ffn_output = self.ffn(normed_x, labels)
+        x = x + self.R2(ffn_output)
+        return x
+    
+class LLMMini(nn.Module):
+    """
+    학습(Train) 전용 LLM
+    """
+    def __init__(self, vocab, seq, d, layers, heads, kv_heads, f=4, use_bias=True, dtype = mx.bfloat16, num_experts=1):
+        super().__init__()
+        self.dtype = dtype
+        self.embed = Embedding(vocab, d, dtype=dtype)
+        rope = rope_cache(seq, d // heads)
+        self.blocks = [Block(d, heads, kv_heads, rope, f, use_bias, num_experts, dtype=dtype) for _ in range(layers)]
+        self.norm = RMSNorm(d, dtype = dtype)
+        self.lm_head = Linear(d, vocab, bias=False, dtype=dtype)
+        self.lm_head.weight = self.embed.tok.weight
+
+    def __call__(self, ids, labels: mx.array, m=None):
+        x, _ = self.embed(ids)
+
+        for _, b in enumerate(self.blocks):
+            x = b(x, labels, m)
+
+        x_norm = self.norm(x)
+        logits = self.lm_head(x_norm)
+        return logits
+    
+# --------------------------- Checkpoint I/O --------------------------------
+def save_ckpt(model: nn.Module, optimizer: optim.Optimizer, step: int, ckpt_dir: pathlib.Path, meta: dict):
+    ckpt_dir.mkdir(parents=True, exist_ok=True)
+    
+    # 가중치와 옵티마이저 상태를 별도의 파일에 저장
+    weights_path = ckpt_dir / f"ckpt_{step:06d}_weights.safetensors"
+    opt_path = ckpt_dir / f"ckpt_{step:06d}_optimizer.safetensors"
+    j_path = ckpt_dir / f"ckpt_{step:06d}.json"
+    
+    model.save_weights(str(weights_path))
+
+    flat_optimizer_state = dict(tree_flatten(optimizer.state))
+    mx.save_safetensors(str(opt_path), flat_optimizer_state)
+    
+    n_params = sum(v.size for _, v in tree_flatten(model.parameters()))
+    with open(j_path, "w") as jf:
+        json.dump(meta | {"step": step, "n_params": n_params}, jf, indent=2)
+
+    print(f"[ckpt] saved model & optimizer → {ckpt_dir}")
+
+# [수정] load_ckpt 함수가 optimizer 객체를 받아 상태를 로드하도록 변경
+def load_ckpt(model: nn.Module, optimizer: optim.Optimizer, ckpt_path: pathlib.Path):
+    # ckpt_path는 이제 'ckpt_xxxxxx.json' 파일을 가리킵니다.
+    if not ckpt_path.exists():
+        sys.exit(f"checkpoint metadata {ckpt_path} not found")
+
+    step = 0
+    with open(ckpt_path, "r") as jf:
+        meta = json.load(jf)
+        step = meta.get("step", 0)
+
+    weights_path = ckpt_path.with_name(f"ckpt_{step:06d}_weights.safetensors")
+    opt_path = ckpt_path.with_name(f"ckpt_{step:06d}_optimizer.safetensors")
+
+    if not weights_path.exists():
+        sys.exit(f"Weight file {weights_path} not found")
+        
+    print(f"[ckpt] loading model weights ← {weights_path}...")
+    model.load_weights(str(weights_path))
+
+    if optimizer is not None and opt_path.exists():
+        print(f"[ckpt] loading optimizer state ← {opt_path}...")
+        opt_state = mx.load(str(opt_path))
+        optimizer.state = tree_unflatten(list(opt_state.items()))
+    
+    print(f"[ckpt] resumed from step {step}")
+    return step
+
+# ----------------------------DATA LOADING-----------------------------------
+def bin_loader(data_path: str, label_path: str, block: int, batch: int):
+    """
+    토큰과 라벨 파일을 함께 읽어 (x, y, labels) 튜플을 반환
+    """
+    ids_dtype = np.uint32
+    labels_dtype = np.uint8
+    
+    tokens = np.memmap(data_path, dtype=ids_dtype, mode='r')
+    labels = np.memmap(label_path, dtype=labels_dtype, mode='r')
+    
+    # 토큰과 라벨의 길이가 같은지 확인
+    assert len(tokens) == len(labels), "Data and label files must have the same length"
+    
+    N = len(tokens) - (block + 1)
+    
+    while True:
+        ix = np.random.randint(0, N, size=batch)
+        
+        # 입력 x: (batch, block)
+        x_buf = np.stack([tokens[i:i+block] for i in ix])
+        # 타겟 y: (batch, block)
+        y_buf = np.stack([tokens[i+1:i+block+1] for i in ix])
+        # 라벨 labels: (batch, block)
+        l_buf = np.stack([labels[i:i+block] for i in ix])
+        
+        yield mx.array(x_buf), mx.array(y_buf), mx.array(l_buf)
+
+
+# ------------------------------TRAIN LOOP-----------------------------------
+def build_opt(lr: float, wd: float, betas = (0.9, 0.95)):
+    return optim.Lion(
+        learning_rate=lr,
+        weight_decay=wd,
+        betas=betas
+    )
+
+def lr_sched(step,total,warm,max_lr,min_lr):
+    if step<warm:
+        return max_lr*step/warm
+    prog=(step-warm)/(total-warm)
+    return min_lr + (max_lr-min_lr)*0.5*(1+math.cos(math.pi*prog))
+
+def train(model, optimizer, steps:int, lr:float, batch:int, train_iter, val_iter,
+          eval_int:int, save_int:int, block:int, ckpt_dir:pathlib.Path,
+          meta:dict, start_step:int, accum:int = 1, dtype=mx.float32):
+
+    global _DEBUG_STEP, _DEBUG_ENABLED
+
+    cmask = causal_mask(block, dtype=dtype)
+    warm = max(100, steps // 20)
+
+    # --- 가시적인 그래디언트 Norm을 계산하는 헬퍼 함수 ---
+    # def get_grad_norm(grads_tree):
+    #     norm = mx.array(0.0, mx.float32)
+    #     for _, g in tree_flatten(grads_tree):
+    #         if g is not None:
+    #             norm += mx.sum(g.astype(mx.float32) ** 2)
+    #     return mx.sqrt(norm)
+    
+    # ------------------ 상태(State) 정의 ------------------
+    # 학습과 평가에서 공통으로 사용할 상태
+    # model, optimizer 등은 mutable 객체이므로 딕셔너리에 넣어도 참조가 유지됩니다.
+    train_state = {
+        "model": model,
+        "optimizer": optimizer,
+    }
+    eval_state = {
+        "model": model,
+    }
+
+    # [1. 컴파일된 학습 스텝]
+    # 이전과 마찬가지로, Metal 버그 회피를 위해 클리핑/업데이트는 제외합니다.
+    # @partial(mx.compile, inputs=train_state, outputs=train_state["model"])
+    def compiled_train_loss_and_grad(x, y, labels):
+        def loss_fn(mdl, x_in, y_in, labels_in):
+            logits = mdl(x_in, labels_in, cmask)
+            return mx.mean(nn.losses.cross_entropy(
+                logits.reshape(-1, logits.shape[-1]), y_in.reshape(-1), reduction="none"
+            ))
+        
+        value_and_grad_fn = nn.value_and_grad(train_state["model"], loss_fn)
+        loss, grads = value_and_grad_fn(train_state["model"], x, y, labels)
+        return loss, grads
+
+    # [2. 컴파일된 평가 스텝]
+    # 평가 시에는 그래디언트가 필요 없으므로, loss 계산만 컴파일합니다.
+    # @partial(mx.compile, inputs=eval_state, outputs=eval_state["model"])
+    def compiled_eval_loss(x, y, labels):
+        logits = model(x, labels, cmask)
+        loss = mx.mean(nn.losses.cross_entropy(
+            logits.reshape(-1, logits.shape[-1]), y.reshape(-1), reduction="none"
+        ))
+        return loss
+
+    # --- 그래디언트 클리핑 함수 (컴파일되지 않음) ---
+    def clip_grads(tree, max_norm=1.0):
+        sq = mx.zeros((), dtype=mx.float32)
+        is_finite = mx.all(mx.stack([mx.all(mx.isfinite(g)) for _, g in tree_flatten(tree)]))
+        if not is_finite.item():
+             print(f"Warning: NaN or Inf found in gradients at step {_DEBUG_STEP}. Skipping update.")
+             return tree_map(lambda p: mx.zeros_like(p), tree)
+        for _, g in tree_flatten(tree):
+            sq += mx.sum(g.astype(mx.float32) ** 2)
+        norm = mx.sqrt(sq)
+        scale = mx.minimum(1.0, max_norm / (norm + 1e-6))
+        return tree_map(lambda g: g * scale, tree)
+
+    # --- 메인 학습 루프 ---
+    for s in range(start_step, start_step + steps):
+        _DEBUG_STEP = s
+        optimizer.learning_rate = lr_sched(s - start_step, steps, warm, lr, lr * 0.05)
+        
+        tot_loss = 0.0
+        grad_acc = tree_map(lambda p: mx.zeros_like(p), model.parameters())
+        # 가시적 확인을 위한 그래디언트 분석
+        # current_batch_labels = None
+
+        for _ in range(accum):
+            # 컴파일된 함수 호출
+            x, y, labels = next(train_iter)
+            # 가시적 확인을 위한 그래디언트 분석
+            # if _ == accum - 1:
+            #     current_batch_labels = labels
+            loss, grads = compiled_train_loss_and_grad(x, y, labels)
+            grad_acc = tree_map(lambda acc, new: acc + new, grad_acc, grads)
+            tot_loss += loss.item()
+
+        grad_acc = tree_map(lambda g: g / accum, grad_acc)
+
+        # 컴파일되지 않은 후처리 단계
+        clipped_grads = clip_grads(grad_acc)
+        optimizer.update(model, clipped_grads)
+        mx.eval(model.parameters(), optimizer.state)
+
+        # # 가시적 확인을 위한 그래디언트 분석
+        # if (s + 1) % 10 == 0:
+        #     print("-" * 50)
+        #     print(f"Step {s+1} Gradient Analysis:")
+            
+        #     # 현재 배치에 어떤 전문가들이 있었는지 확인
+        #     unique_labels_in_batch = sorted(np.unique(current_batch_labels.tolist()).tolist())
+        #     print(f"  > Active experts in this batch: {unique_labels_in_batch}")
+
+        #     # 모델의 모든 ffn 레이어(Block)를 순회하며 그래디언트 확인
+        #     for i, block in enumerate(model.blocks):
+        #         # block.ffn은 MOELayer 인스턴스
+        #         # grad_acc 딕셔너리에서 해당 블록의 ffn 그래디언트를 가져옴
+        #         ffn_grads = grad_acc['blocks'][i]['ffn']
+                
+        #         expert_grad_norms = []
+        #         for exp_idx in range(len(block.ffn.experts)):
+        #             # 각 전문가의 그래디언트만 추출
+        #             expert_grad_tree = ffn_grads['experts'][exp_idx]
+                    
+        #             # 그래디언트 Norm 계산
+        #             norm = get_grad_norm(expert_grad_tree)
+        #             mx.eval(norm) # 계산 실행
+        #             expert_grad_norms.append(f"{norm.item():.4f}")
+                
+        #         print(f"  > Block {i} FFN Grad Norms: [ {' | '.join(expert_grad_norms)} ]")
+        #     print("-" * 50)
+
+        # 로그 및 평가 (이전과 동일)
+        if (s + 1) % eval_int == 0:
+            vx, vy, vlabels = next(val_iter)
+            # 컴파일된 평가 함수를 호출합니다.
+            v_loss = compiled_eval_loss(vx, vy, vlabels)
+            
+            # v_loss.item()을 호출하기 전 mx.eval()을 명시적으로 호출하여 평가 그래프 계산을 완료하고 동기화
+            mx.eval(v_loss)
+            
+            perplexity = math.exp(v_loss.item())
+            print(f"{s+1:>7} | tr {tot_loss/accum:.4f} | "
+                  f"Perplexity {perplexity:.2f}")
+                  
+        elif (s + 1) % 10 == 0 or s == start_step:
+            print(f"{s+1:>7} | loss {tot_loss/accum:.4f}")
+
+        if (s + 1) % save_int == 0:
+            save_ckpt(model, optimizer, s + 1, ckpt_dir, meta)
+    save_ckpt(model, optimizer, start_step + steps, ckpt_dir, meta)
+
+# -----------------------TOKENISER / VOCAB HELPERS---------------------------
+def load_encoding(name: str) -> Tuple[tiktoken.Encoding, int]:
+    enc = tiktoken.get_encoding(name)
+    n_vocab = enc.max_token_value + 1
+    return enc, n_vocab
+
+LLM_CONFIG: Dict[str, Dict] = {
+    "custom":      dict(num_layers=16,  num_heads=16,   embd_dim=512,   block_size=1024,   use_bias=True,   LR=5e-6,  num_experts=8),
+    "nano":        dict(num_layers=4,   num_heads=4,    embd_dim=512,   block_size=1024,   use_bias=True,   LR=1e-5,  num_experts=4),
+    "gpt2":        dict(num_layers=12,  num_heads=12,   embd_dim=768,   block_size=1024,   use_bias=True,   LR=1e-5,  num_experts=8),
+    "gpt2-medium": dict(num_layers=24,  num_heads=16,   embd_dim=1024,  block_size=1024,   use_bias=True,   LR=1e-5,  num_experts=8),
+    "gpt2-large":  dict(num_layers=36,  num_heads=20,   embd_dim=1280,  block_size=1024,   use_bias=True,   LR=1e-5,  num_experts=8),
+    "gpt2-xl":     dict(num_layers=48,  num_heads=25,   embd_dim=1600,  block_size=1024,   use_bias=True,   LR=1e-5,  num_experts=16),
+}
+
+# PYTHONPATH=. uv run examples/GatelessMoELLM/train.py --preset custom --train_steps 10000 --kv_heads 16
+# PYTHONPATH=. uv run examples/GatelessMoELLM/train.py --preset custom --train_steps 10000 --kv_heads 16 --resume ckpt_000000.json
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--preset", choices=LLM_CONFIG)
+    ap.add_argument("--enc", default="o200k_base")
+    ap.add_argument("--kv_heads", type=int, default=None)
+    ap.add_argument("--data_dir", type=str, default="./")
+    ap.add_argument("--train_steps", type=int, default=0)
+    ap.add_argument("--batch_size", type=int, default=8)
+    ap.add_argument("--eval_every", type=int, default=50)
+    ap.add_argument("--save_every", type=int, default=100)
+    ap.add_argument("--ckpt_dir", type=str, default="moe_ckpts")
+    ap.add_argument("--resume", type=str, default=None)
+    ap.add_argument("--accum-steps", type=int, default=1, help="Number of gradient accumulation steps.")
+    args = ap.parse_args()
+
+    enc, vocab_size = load_encoding(args.enc)
+    cfg = LLM_CONFIG[args.preset]
+    kv_heads = args.kv_heads or max(1, cfg["num_heads"]//4)
+
+    model = LLMMini(
+        vocab_size, 
+        cfg["block_size"], 
+        cfg["embd_dim"], 
+        cfg["num_layers"], 
+        cfg["num_heads"], 
+        kv_heads,
+        use_bias = cfg["use_bias"],
+        dtype = mx.bfloat16,
+        num_experts = cfg["num_experts"]
+    )
+    optimizer = build_opt(cfg["LR"], 0.01)
+    n_params = count_params(model.parameters()) / 1e6
+    print(f"{args.preset}: {n_params:.1f}M | heads {cfg['num_heads']} / kv {kv_heads} | vocab {vocab_size}")
+
+    start_step = 0
+    if args.resume:
+        start_step = load_ckpt(model, optimizer, pathlib.Path(args.ckpt_dir) / args.resume)
+
+    if args.train_steps and args.data_dir:
+        tbin_ids = pathlib.Path(args.data_dir) / "train_ids.bin"
+        tbin_labels = pathlib.Path(args.data_dir) / "train_labels.bin"
+        vbin_ids = pathlib.Path(args.data_dir) / "val_ids.bin"
+        vbin_labels = pathlib.Path(args.data_dir) / "val_labels.bin"
+        if not all([f.exists() for f in [tbin_ids, tbin_labels, vbin_ids, vbin_labels]]):
+            sys.exit("One or more data/label .bin files are missing.")
+        train_iter = bin_loader(str(tbin_ids), str(tbin_labels), cfg["block_size"], args.batch_size)
+        val_iter = bin_loader(str(vbin_ids), str(vbin_labels), cfg["block_size"], args.batch_size)
+        meta = {"preset":args.preset,"kv_heads":kv_heads,"enc":args.enc}
+        train(
+            model,
+            optimizer,
+            args.train_steps,
+            cfg["LR"],
+            args.batch_size,
+            train_iter,
+            val_iter,
+            args.eval_every,
+            args.save_every,
+            cfg["block_size"],
+            pathlib.Path(args.ckpt_dir),
+            meta,start_step,
+            args.accum_steps,
+            dtype=mx.bfloat16)
+    elif args.train_steps:
+        print("--data_dir absent: using random tokens")
+    else:
+        print("Build OK – specify --train_steps + --data_dir to start training.")


### PR DESCRIPTION
- MoE(Mixture-of-Experts) 구현을 위한 구조적 확장
	- Linear, GRN 레이어에 functional_forward(함수형 경로) 정적 메서드 추가
	- vmap/모델 파라미터 명시적 라우팅 등 함수형 MoE 연산 지원
	- common.py에 one_hot 유틸리티 함수 도입
	- MLX에서의 라벨 기반 MoE 라우팅 효율화 목적
- LatentAttention 학습용 커널 최적화
	- 불필요한 드롭아웃 제거, 어텐션 커널 직결형 구조로 단순화
	- 대규모 실험 및 분산 학습에서 FLOPs, 성능 개선 기대
- GatelessMoELLM 예제 추가
	- 학습/추론 전용 스크립트(examples/GatelessMoELLM/train.py, generate.py) 최초 도입
	- 전문가 라벨 기반 동적 MoE 라우팅, inference시 expert mix(가중 조합) 지정 기능 구현
	- vmap+einsum 기반 실제 라우팅 로직 반영, 라벨/가중치 에러 핸들링 및 자동 정규화 포함